### PR TITLE
Remove default features from `image` crate

### DIFF
--- a/glacier-texture/Cargo.toml
+++ b/glacier-texture/Cargo.toml
@@ -20,7 +20,7 @@ thiserror = "2.0.16"
 serde = { version = "1.0.219", features = ["serde_derive"]}
 rpkg-rs = { version = "1.3.1", features = ["path-list"], optional = true }
 png = "0.17.16"
-image = { version = "0.25.6" , optional = true}
+image = { version = "0.25.6" , default-features = false, optional = true }
 
 [dev-dependencies]
 clap = { version = "4.5.23", features = ["derive"] }


### PR DESCRIPTION
As title. By default it enables all formats, which is not necessary and can be specified by the downstream dependency anyway (which will have to do so to create a DynamicImage in the first place)